### PR TITLE
ui: Improve mobile responsiveness

### DIFF
--- a/app/components/DialectSlider.vue
+++ b/app/components/DialectSlider.vue
@@ -132,28 +132,32 @@ function pick(i: number) { stop(); go(i) }
     <div class="flex items-center justify-between border-t border-outline px-3 py-2">
       <button
         type="button"
-        class="inline-flex h-8 w-8 items-center justify-center rounded-full text-on-surface-variant hover:bg-surface-2"
+        class="inline-flex h-9 w-9 items-center justify-center rounded-full text-on-surface-variant hover:bg-surface-2"
         aria-label="Previous dialect"
         @click="pick(idx - 1)"
       >
         <span class="material-symbols-outlined" style="font-size:20px">chevron_left</span>
       </button>
-      <div class="flex gap-1.5">
+      <div class="flex items-center">
         <button
           v-for="(l, i) in lenses"
           :key="l.region"
           type="button"
-          class="h-1.5 rounded-full transition-all"
-          :class="i === idx ? 'w-5' : 'w-1.5 bg-outline-strong hover:bg-on-surface-variant'"
-          :style="i === idx ? { background: active.accent } : {}"
+          class="group px-1.5 py-3"
           :aria-label="`Show ${l.region}`"
           :aria-current="i === idx"
           @click="pick(i)"
-        />
+        >
+          <span
+            class="block h-1.5 rounded-full transition-all"
+            :class="i === idx ? 'w-5' : 'w-1.5 bg-outline-strong group-hover:bg-on-surface-variant'"
+            :style="i === idx ? { background: active.accent } : {}"
+          />
+        </button>
       </div>
       <button
         type="button"
-        class="inline-flex h-8 w-8 items-center justify-center rounded-full text-on-surface-variant hover:bg-surface-2"
+        class="inline-flex h-9 w-9 items-center justify-center rounded-full text-on-surface-variant hover:bg-surface-2"
         aria-label="Next dialect"
         @click="pick(idx + 1)"
       >

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -127,7 +127,7 @@ onBeforeUnmount(() => {
       </div>
       <div class="border-t border-white/10">
         <div class="mx-auto max-w-6xl px-4 py-5 text-xs text-on-inverse-surface/60">
-          &copy; {{ year }} Pidgin Wiki. Content licensed CC-BY-4.0.
+          &copy; {{ year }} Pidgin Wiki.
         </div>
       </div>
     </footer>

--- a/app/pages/dictionary/[slug].vue
+++ b/app/pages/dictionary/[slug].vue
@@ -29,11 +29,11 @@ useHead(() => ({
     </nav>
 
     <article class="mt-4">
-      <div class="flex flex-col-reverse gap-6 sm:flex-row sm:items-start">
+      <div class="flex flex-col gap-6 sm:flex-row sm:items-start">
         <div class="min-w-0 flex-1">
           <header class="border-b border-outline pb-4">
             <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-              <h1 class="wiki-title text-5xl text-on-surface">{{ word.headword }}</h1>
+              <h1 class="wiki-title text-4xl text-on-surface sm:text-5xl">{{ word.headword }}</h1>
               <span class="text-on-surface-variant">/ {{ word.respelling }} /</span>
               <ListenButton :text="word.headword" label />
             </div>
@@ -56,7 +56,7 @@ useHead(() => ({
                 </p>
                 <p v-if="sense.example" class="mt-1.5 border-l-2 border-outline pl-3 text-on-surface-variant">
                   &ldquo;{{ sense.example }}&rdquo;
-                  <span v-if="sense.exampleEn" class="italic">— {{ sense.exampleEn }}</span>
+                  <span v-if="sense.exampleEn" class="italic">({{ sense.exampleEn }})</span>
                 </p>
               </div>
             </li>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -69,7 +69,7 @@ function onSearch() {
               <span class="inline-flex items-center gap-1.5 rounded-full border border-outline bg-surface px-3 py-1 text-xs font-semibold text-on-surface-variant shadow-sm">
                 <span class="leading-none">{{ tagline.flag }}</span>{{ tagline.lang }}
               </span>
-              <h1 class="wiki-title mx-auto mt-3 max-w-2xl text-3xl leading-tight text-on-surface sm:text-4xl">
+              <h1 class="wiki-title mx-auto mt-3 max-w-2xl text-2xl leading-tight text-on-surface sm:text-4xl">
                 {{ tagParts.a }} <span class="text-primary">{{ tagParts.b }}</span>
               </h1>
             </div>
@@ -108,8 +108,8 @@ function onSearch() {
     </section>
 
     <!-- Main page: featured article + side rail -->
-    <div class="mx-auto grid max-w-6xl gap-8 px-4 py-10 lg:grid-cols-3">
-      <main class="lg:col-span-2">
+    <div class="mx-auto grid max-w-6xl grid-cols-1 gap-8 px-4 py-10 lg:grid-cols-3">
+      <main class="min-w-0 lg:col-span-2">
         <h2 class="wiki-h text-xl text-on-surface">
           <span class="flex items-center gap-2">
             <span class="kente-bar h-4 w-1.5 rounded-full" aria-hidden="true" />
@@ -119,7 +119,7 @@ function onSearch() {
         </h2>
 
         <article v-if="featured" class="mt-5">
-          <div class="flex flex-col-reverse gap-6 sm:flex-row sm:items-start">
+          <div class="flex flex-col gap-6 sm:flex-row sm:items-start">
             <div class="min-w-0 flex-1">
               <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
                 <h3 class="wiki-title text-4xl text-on-surface">{{ featured.headword }}</h3>
@@ -140,7 +140,7 @@ function onSearch() {
                     </p>
                     <p v-if="sense.example" class="mt-1 border-l-2 border-outline pl-3 text-on-surface-variant">
                       &ldquo;{{ sense.example }}&rdquo;
-                      <span v-if="sense.exampleEn" class="italic">— {{ sense.exampleEn }}</span>
+                      <span v-if="sense.exampleEn" class="italic">({{ sense.exampleEn }})</span>
                     </p>
                   </div>
                 </li>
@@ -197,7 +197,7 @@ function onSearch() {
       </main>
 
       <!-- Side rail -->
-      <aside class="space-y-6">
+      <aside class="min-w-0 space-y-6">
         <section v-if="wotd" class="overflow-hidden rounded-lg border border-outline bg-surface">
           <h2 class="wiki-box-h text-on-surface" style="--accent: var(--color-kente-gold)">Word of the day</h2>
           <div class="px-4 py-3">


### PR DESCRIPTION
Fix horizontal scroll on phones: the home page content grid had no constrained column on small screens, so the dialect slider stretched the layout past the viewport and clipped the cards. Constrain the column and let its content shrink.

Also enlarge the dialect slider controls for touch, lead with the word and its meaning instead of the infobox on small screens, scale down oversized headings, and drop a stale licensing line from the footer.